### PR TITLE
Encode zipped file string as UTF-8

### DIFF
--- a/tap_fullstory/__init__.py
+++ b/tap_fullstory/__init__.py
@@ -60,7 +60,7 @@ def get_start(key):
 def unzip_to_json(content):
     content_io = io.BytesIO(content)
     content_gz = gzip.GzipFile(fileobj=content_io, mode='rb')
-    decoded = io.TextIOWrapper(content_gz).read()
+    decoded = io.TextIOWrapper(content_gz, encoding='utf-8').read()
     return json.loads(decoded)
 
 


### PR DESCRIPTION
I believe this fixes an issue I'm having in production in Stitch. You can see my support requests and error logs in Intercom under james@expectedbehavior.com. 

I verified locally that this is the issue by setting the encoding to `ascii`. I then received the error noted in production. When I set it to utf, the error went away and the code worked as expected.

This appears to be related to some sort of system setting, that sets the default encoding, and I gues it's currently set to ascii.