### PR TITLE
Add new fields; refine 429 handling

### DIFF
--- a/tap_fullstory/__init__.py
+++ b/tap_fullstory/__init__.py
@@ -81,11 +81,10 @@ def on_giveup(details):
 
 @backoff.on_exception(backoff.expo,
                       requests.exceptions.RequestException,
-                      max_tries=5,
+                      max_tries=6,
                       giveup=giveup,
                       on_giveup=on_giveup,
                       factor=2)
-@utils.ratelimit(9, 1)
 def request(endpoint, params=None):
     url = BASE_URL + endpoint
     params = params or {}
@@ -101,12 +100,12 @@ def request(endpoint, params=None):
         resp = SESSION.send(req)
         timer.tags[metrics.Tag.http_status_code] = resp.status_code
 
+    resp.raise_for_status()
+
     if resp.headers.get('Content-Type') == "application/gzip":
         json_body = unzip_to_json(resp.content)
     else:
         json_body = resp.json()
-
-    resp.raise_for_status()
 
     return json_body
 

--- a/tap_fullstory/schemas/events.json
+++ b/tap_fullstory/schemas/events.json
@@ -26,6 +26,18 @@
     "EventTargetSelectorTok": {
         "type": ["null", "string"]
     },
+    "EventModFrustrated": {
+      "type": ["null", "integer"]
+    },
+    "EventModDead": {
+      "type": ["null", "integer"]
+    },
+    "EventModError": {
+      "type": ["null", "integer"]
+    },
+    "EventModSuspicious": {
+      "type": ["null", "integer"]
+    },
     "PageDuration": {
         "type": ["null", "integer"]
     },
@@ -64,6 +76,18 @@
     },
     "PageNumErrors": {
         "type": ["null", "integer"]
+    },
+    "PageClusterId": {
+      "type": ["null", "integer"]
+    },
+    "LoadDomContentTime": {
+      "type": ["null", "integer"]
+    },
+    "LoadEventTime": {
+      "type": ["null", "integer"]
+    },
+    "LoadFirstPaintTime": {
+      "type": ["null", "integer"]
     },
     "UserAppKey": {
         "type": ["null", "string"]


### PR DESCRIPTION
This PR has two distinct parts:
1. It adds a series of fields to the schema that have been added to the FullStory data export since the creation of this tap.
2 It refines handling of 429 errors to better account for FullStory's rate limiting, which allows for a burst of 50 downloads, then subsequently rate limits the downloads to 2/min.