### PR TITLE
Bump singer-python to v1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.4
+  * Update version of `singer-python` to `1.9.1` to allow JSON serialisation of `Decimal` types
+
 ## 1.0.3
   * Update version of `requests` to `2.20.0` in response to CVE 2018-18074
 

--- a/setup.py
+++ b/setup.py
@@ -3,14 +3,14 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-fullstory',
-      version='1.0.3',
+      version='1.0.4',
       description='Singer.io tap for extracting data from the FullStory API',
       author='Stitch',
       url='http://singer.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_fullstory'],
       install_requires=[
-          'singer-python==1.6.0',
+          'singer-python==1.9.1',
           'requests==2.20.0',
           'backoff==1.3.2',
           'pendulum==1.2.0',


### PR DESCRIPTION
# Description of change

~3 years ago, `singer-python` was [patched to fix issues with the standard JSON encoder failing to encode Decimal types](https://github.com/singer-io/singer-python/pull/23). 

Bumping the version of `singer-python` to its max minor version (1.9.1) should fix this issue.

Example error 

```
2020-03-13 01:00:54,987Z    tap - Traceback (most recent call last):
2020-03-13 01:00:54,987Z    tap -   File "tap-env/bin/tap-fullstory", line 9, in <module>
2020-03-13 01:00:54,987Z    tap -     load_entry_point('tap-fullstory==1.0.3', 'console_scripts', 'tap-fullstory')()
2020-03-13 01:00:54,988Z    tap -   File "/code/orchestrator/tap-env/lib/python3.5/site-packages/tap_fullstory/__init__.py", line 162, in main
2020-03-13 01:00:54,988Z    tap -     do_sync()
2020-03-13 01:00:54,988Z    tap -   File "/code/orchestrator/tap-env/lib/python3.5/site-packages/tap_fullstory/__init__.py", line 154, in do_sync
2020-03-13 01:00:54,988Z    tap -     sync_events()
2020-03-13 01:00:54,988Z    tap -   File "/code/orchestrator/tap-env/lib/python3.5/site-packages/tap_fullstory/__init__.py", line 146, in sync_events
2020-03-13 01:00:54,988Z    tap -     singer.write_record("events", event)
2020-03-13 01:00:54,988Z    tap -   File "/code/orchestrator/tap-env/lib/python3.5/site-packages/singer/__init__.py", line 61, in write_record
2020-03-13 01:00:54,988Z    tap -     write_message(RecordMessage(stream=stream_name, record=record))
2020-03-13 01:00:54,988Z    tap -   File "/code/orchestrator/tap-env/lib/python3.5/site-packages/singer/__init__.py", line 52, in write_message
2020-03-13 01:00:54,988Z    tap -     sys.stdout.write(message.tojson() + '\n')
2020-03-13 01:00:54,989Z    tap -   File "/code/orchestrator/tap-env/lib/python3.5/site-packages/singer/__init__.py", line 33, in tojson
2020-03-13 01:00:54,989Z    tap -     return json.dumps(self.asdict())
2020-03-13 01:00:54,989Z    tap -   File "/root/.pyenv/versions/3.5.2/lib/python3.5/json/__init__.py", line 230, in dumps
2020-03-13 01:00:54,989Z    tap -     return _default_encoder.encode(obj)
2020-03-13 01:00:54,989Z    tap -   File "/root/.pyenv/versions/3.5.2/lib/python3.5/json/encoder.py", line 198, in encode
2020-03-13 01:00:54,989Z    tap -     chunks = self.iterencode(o, _one_shot=True)
2020-03-13 01:00:54,989Z    tap -   File "/root/.pyenv/versions/3.5.2/lib/python3.5/json/encoder.py", line 256, in iterencode
2020-03-13 01:00:54,989Z    tap -     return _iterencode(o, 0)
2020-03-13 01:00:54,989Z    tap -   File "/root/.pyenv/versions/3.5.2/lib/python3.5/json/encoder.py", line 179, in default
2020-03-13 01:00:54,989Z    tap -     raise TypeError(repr(o) + " is not JSON serializable")
2020-03-13 01:00:54,989Z    tap - TypeError: Decimal('24.1444') is not JSON serializable
```

# Manual QA steps
 - 
 
# Risks
 - minor version bump so no breaking changes expected
 
# Rollback steps
 - revert this branch
