### PR TITLE
Move parameterized from install_requires to extras_require[dev]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.1
+  * Bump requests to 2.33.0 (CVE-2026-25645)
+
 # Changelog
 
 ## 2.0.0

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,12 @@ setup(name="tap-fullstory",
         "singer-python==6.1.1",
         "requests==2.32.4",
         "backoff==2.2.1",
-        "parameterized"
       ],
+      extras_require={
+        "dev": [
+          "parameterized",
+        ],
+      },
       entry_points="""
           [console_scripts]
           tap-fullstory=tap_fullstory:main

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="tap-fullstory",
-      version="2.0.0",
+      version="2.0.1",
       description="Singer.io tap for extracting data from fullstory API",
       author="Stitch",
       url="http://singer.io",
@@ -12,7 +12,7 @@ setup(name="tap-fullstory",
       py_modules=["tap_fullstory"],
       install_requires=[
         "singer-python==6.1.1",
-        "requests==2.32.4",
+        "requests==2.33.0",
         "backoff==2.2.1",
       ],
       extras_require={


### PR DESCRIPTION
## Summary

`parameterized` is only used in test files (`tests/unittests/test_client.py`) and should not be included in the production image.

This moves it to `extras_require[dev]` so it is still installed via `pip install .[dev]` in CI but excluded from the final deployed artifact.